### PR TITLE
Added configuration for WebP image style overrides

### DIFF
--- a/recipes/dxpr_builder_base/config/image.style.dxpr_builder_media_thumbnail.yml
+++ b/recipes/dxpr_builder_base/config/image.style.dxpr_builder_media_thumbnail.yml
@@ -1,0 +1,23 @@
+uuid: 7ea64269-0429-4fd8-8666-290d93a4616b
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: YzZh6H_mXyPGZIh537BXwZWEr6H3Ca5-VwRZRiSM87s
+name: dxpr_builder_media_thumbnail
+label: 'DXPR Builder Media thumbnail'
+effects:
+  1d899e87-51e4-4467-90db-e516c31d4688:
+    uuid: 1d899e87-51e4-4467-90db-e516c31d4688
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 300
+      height: null
+      anchor: center-center
+  dc3574ca-8b7e-4639-a785-97aaf8fe3e1c:
+    uuid: dc3574ca-8b7e-4639-a785-97aaf8fe3e1c
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/recipes/dxpr_builder_base/config/image.style.large.yml
+++ b/recipes/dxpr_builder_base/config/image.style.large.yml
@@ -1,0 +1,23 @@
+uuid: 8658111e-579e-4f79-abf5-151ba32ec3d3
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: J2n0RpFzS0-bgSyxjs6rSdgxB1rb-bTAgqywNx_964M
+name: large
+label: 'Large (480×480)'
+effects:
+  ddd73aa7-4bd6-4c85-b600-bdf2b1628d1d:
+    uuid: ddd73aa7-4bd6-4c85-b600-bdf2b1628d1d
+    id: image_scale
+    weight: 0
+    data:
+      width: 480
+      height: 480
+      upscale: false
+  d0671503-e0f9-4c68-9006-5579332c99ef:
+    uuid: d0671503-e0f9-4c68-9006-5579332c99ef
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/recipes/dxpr_builder_base/config/image.style.media_library.yml
+++ b/recipes/dxpr_builder_base/config/image.style.media_library.yml
@@ -1,0 +1,26 @@
+uuid: fd644cb9-55c1-407c-b280-eb3a86b3155a
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - media_library
+_core:
+  default_config_hash: 7qJqToD1OQLAyeswpmg7M0LRxQlw1URQkJDWUJCnmR8
+name: media_library
+label: 'Media Library thumbnail (220×220)'
+effects:
+  75b076a8-1234-4b42-85db-bf377c4d8d5f:
+    uuid: 75b076a8-1234-4b42-85db-bf377c4d8d5f
+    id: image_scale
+    weight: 0
+    data:
+      width: 220
+      height: 220
+      upscale: false
+  fea1399c-49a8-4b6e-94eb-c8cbc0bdea60:
+    uuid: fea1399c-49a8-4b6e-94eb-c8cbc0bdea60
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/recipes/dxpr_builder_base/config/image.style.medium.yml
+++ b/recipes/dxpr_builder_base/config/image.style.medium.yml
@@ -1,0 +1,23 @@
+uuid: db29bfa8-1123-462d-8e4a-db839679498c
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: Y9NmnZHQq20ASSyTNA6JnwtWrJJiSajOehGDtmUFdM0
+name: medium
+label: 'Medium (220×220)'
+effects:
+  bddf0d06-42f9-4c75-a700-a33cafa25ea0:
+    uuid: bddf0d06-42f9-4c75-a700-a33cafa25ea0
+    id: image_scale
+    weight: 0
+    data:
+      width: 220
+      height: 220
+      upscale: false
+  42c5134e-15a4-4d0c-8511-621c0eea57f9:
+    uuid: 42c5134e-15a4-4d0c-8511-621c0eea57f9
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/recipes/dxpr_builder_base/config/image.style.thumbnail.yml
+++ b/recipes/dxpr_builder_base/config/image.style.thumbnail.yml
@@ -1,0 +1,23 @@
+uuid: 28ec0efd-1315-4dab-ab03-20a0d51023a8
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: cCiWdBHgLwj5omG35lsKc4LkW4MBdmcctkVop4ol5x0
+name: thumbnail
+label: 'Thumbnail (100×100)'
+effects:
+  1cfec298-8620-4749-b100-ccb6c4500779:
+    uuid: 1cfec298-8620-4749-b100-ccb6c4500779
+    id: image_scale
+    weight: 0
+    data:
+      width: 100
+      height: 100
+      upscale: false
+  21217a69-c444-4a97-9d08-babca14a397c:
+    uuid: 21217a69-c444-4a97-9d08-babca14a397c
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp

--- a/recipes/dxpr_builder_base/config/image.style.wide.yml
+++ b/recipes/dxpr_builder_base/config/image.style.wide.yml
@@ -1,0 +1,23 @@
+uuid: 786716e6-d1a7-4092-94f5-9b5d9761ba75
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: LswCVLg8z4Zk1u6pV1Dpj1qUj5YY2CQ7_ojx7bJQ8qk
+name: wide
+label: 'Wide (1090)'
+effects:
+  09959c15-59ce-4f6d-90df-e2d7cf32bce5:
+    uuid: 09959c15-59ce-4f6d-90df-e2d7cf32bce5
+    id: image_scale
+    weight: 1
+    data:
+      width: 1090
+      height: null
+      upscale: false
+  730517a2-7f8d-41e1-aa72-75cdf836d70b:
+    uuid: 730517a2-7f8d-41e1-aa72-75cdf836d70b
+    id: image_convert
+    weight: 2
+    data:
+      extension: webp


### PR DESCRIPTION
- #3 

## Solution

Implemented webP image style override configuration into dxpr_base recipe, from https://github.com/dxpr/dxpr_marketing_cms/pull/57

<img width="1470" alt="Screenshot 2024-07-31 at 2 55 32 PM" src="https://github.com/user-attachments/assets/5fe34c9d-903d-4a77-9335-19b7c30c780d">


## Checklist

<!--- Put an `x` in all the boxes that apply: -->
- [x] I have read the [CONTRIBUTING.md](https://github.com/dxpr/dxpr_builder/blob/2.x/CONTRIBUTING.md) document.
- [x] My commit messages follow the contributing standards and style of this project.
- [ ] My code follows the coding standards and style of this project.
- [ ] My code contains no changes that are outside the scope of the issue.
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to change).
- [ ] Need to run update.php after code changes.
- [ ] Requires a change to end-user documentation.
- [ ] Requires a change to developer documentation.
- [ ] Requires a change to QA tests.
- [ ] Requires a new QA test.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
