### PR TITLE
Remove duplicated slash on home page after CMS install

### DIFF
--- a/project_template/web/profiles/dxpr_cms_installer/dxpr_cms_installer.info.yml
+++ b/project_template/web/profiles/dxpr_cms_installer/dxpr_cms_installer.info.yml
@@ -7,7 +7,7 @@ description: 'Provides install-time tweaks for Dxpr CMS. Not to be used in produ
 distribution:
   name: Dxpr CMS
   install:
-    finish_url: '/home'
+    finish_url: 'home'
     theme: dxpr_cms_installer_theme
 
 forms:


### PR DESCRIPTION
### Problem:
Duplicated slash on home page after cms install.

_Before:_
<img width="272" alt="Screenshot 2025-06-28 at 14 35 25" src="https://github.com/user-attachments/assets/625c7e10-715c-4ea2-acd8-e5209cadc1a7" />

_After:_
<img width="272" alt="Screenshot 2025-06-28 at 14 31 45" src="https://github.com/user-attachments/assets/647b8cf1-3f5f-40ab-b0ff-4481f8d32353" />
