### PR TITLE
fix: use standard git diff paths in php-css-lint patch

### DIFF
--- a/patches/php-css-lint--implicit-nullable.patch
+++ b/patches/php-css-lint--implicit-nullable.patch
@@ -1,5 +1,5 @@
---- vendor/neilime/php-css-lint/src/CssLint/Linter.php	2023-06-19 18:35:21
-+++ /dev/fd/12	2026-05-18 11:37:38
+--- a/src/CssLint/Linter.php
++++ b/src/CssLint/Linter.php
 @@ -68,7 +68,7 @@
       * Constructor
       * @param \CssLint\Properties $oProperties (optional) an instance of the "\CssLint\Properties" helper


### PR DESCRIPTION
## Summary
- The php-css-lint implicit-nullable patch used absolute `vendor/` paths which `cweagans/composer-patches` v2 cannot apply from the package root
- Changed to standard `a/`/`b/` prefixed paths relative to the package root (`src/CssLint/Linter.php`)

## Test plan
- [ ] Run `composer install` in a fresh clone and verify the patch applies without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)